### PR TITLE
fix for incorrect escaping of the redirect header's parameters.

### DIFF
--- a/MyID.php
+++ b/MyID.php
@@ -1564,7 +1564,7 @@ function wrap_html ( $message ) {
 <html>
 <head>
 <title>phpMyID</title>
-<link rel="openid.server" href="' . $profile['req_url'] . '" />
+<link rel="openid.server" href="' . htmlentities($profile['req_url'], ENT_QUOTES) . '" />
 <link rel="openid.delegate" href="' . $profile['idp_url'] . '" />
 ' . implode("\n", $profile['opt_headers']) . '
 <meta name="charset" content="' . $charset . '" />
@@ -1717,7 +1717,7 @@ $profile['req_url'] = sprintf("%s://%s%s%s",
 		      $proto,
 		      htmlentities($_SERVER['HTTP_HOST'], ENT_QUOTES),
 		      $port,
-		      htmlentities($_SERVER["REQUEST_URI"], ENT_QUOTES));
+		      $_SERVER["REQUEST_URI"]);
 
 // Set the default allowance for testing
 if (! array_key_exists('allow_test', $profile))


### PR DESCRIPTION
Commit 08a27dcfb5 introduced use of the PHP "htmlentities" function
to rectify some XSS vulnerabilities. In doing so, the redirect sent
back to the client was mis-escaped so that the '&' parameter separator
was represented as '&amp;'. This resulted in the second and following
parameter's names being prefixed with 'amp;' and that stopped the
login process from working.

This commit removes the call to 'htmlentities' on the requested URL
and replaces it with a call where the request is applied to a <link>
tag. This way, it's escaped in the HTML but not in the redirect header.

Works with PHP version 5.6.8.
